### PR TITLE
Merge Scripts and scripts folder

### DIFF
--- a/scripts/OnSuccess.cmd
+++ b/scripts/OnSuccess.cmd
@@ -1,0 +1,2 @@
+git add . 
+git diff --quiet --exit-code --cached || git commit -m "Update Reference Content" && git push -u origin master && echo "Document updated"


### PR DESCRIPTION
Windows doesn't support folder with same name but only different in case.