### PR TITLE
fix reference.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ src/
 _javadocs/
 code2yaml/
 api/.inter/
+_dependentPackages/
 .openpublishing.buildcore.ps1

--- a/docs-ref-mapping/reference.yml
+++ b/docs-ref-mapping/reference.yml
@@ -1,7 +1,6 @@
 - name: Reference 
   uid: azure.java.sdk.landingpage.reference
   landingPageType: Root
-  expanded: true
   items:
   - name: "Active Directory"
     href: ~/docs-ref-services/activedirectory.md


### PR DESCRIPTION
`expanded` in reference.yml is unknown to processing tools and will fail CI build.

https://github.com/Azure/azure-docs-sdk-java/commit/60b47cb15305cd550f79da037a85e8bfba5c4dd7

