### PR TITLE
redirect java/api to java/api/overview/azure

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -3576,7 +3576,7 @@
 	},
 	{
 		"source_path": "index.md",
-		"redirect_url": "/java/azure/index",
+		"redirect_url": "/java/api/overview/azure/index",
 		"redirect_document_id": false
 	}]
 }


### PR DESCRIPTION
redirect https://docs.microsoft.com/en-us/java/api/ to https://docs.microsoft.com/en-us/java/api/overview/azure/. 