### PR TITLE
fix the function link in overview page

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -39,10 +39,11 @@
       },
       {
         "files":[
-          "README.md"
+          "**/README.md"
           ],
         "src":"_functionsref",
         "dest":"api/overview/azure/functions",
+        "group":"stable",
         "version":"azure-java-stable"
       },
       {


### PR DESCRIPTION
Fix bug 38912, the link of the functions in Reference overview page is from another repo but which has not been added in dependence.