### PR TITLE
Remove reference to private-registry branch

### DIFF
--- a/docs-ref-conceptual/spring-framework/deploy-spring-boot-java-app-from-container-registry-using-maven-plugin.md
+++ b/docs-ref-conceptual/spring-framework/deploy-spring-boot-java-app-from-container-registry-using-maven-plugin.md
@@ -61,7 +61,7 @@ In this section, you clone a containerized Spring Boot application and test it l
 
 1. Clone the [Spring Boot on Docker Getting Started] sample project into the directory you created; for example:
    ```shell
-   git clone -b private-registry https://github.com/spring-guides/gs-spring-boot-docker
+   git clone -b https://github.com/spring-guides/gs-spring-boot-docker
    ```
 
 1. Change directory to the completed project; for example:


### PR DESCRIPTION
The branch, `private-registry` does not exist on the Spring repo any more. So let's instruct users to clone from the master branch.